### PR TITLE
darwin: u_int not uint

### DIFF
--- a/server/drivers/rawserial.c
+++ b/server/drivers/rawserial.c
@@ -40,6 +40,7 @@
 
 #include <errno.h>
 #include <limits.h>
+#include <sys/types.h>
 
 #ifdef HAVE_SYS_TIME_H
 # include <sys/time.h>
@@ -60,13 +61,13 @@ typedef struct rawserial_private_data {
 	/** \name Event loop timing. refresh_time and refresh_delta form the
 	 * event loop timing mechanism for configurable update rates.
 	 *@{*/
-	uint refresh_time;		/**< time at the last screen update */
-	uint refresh_delta;		/**< time step to next screen update */
+	u_int refresh_time;		/**< time at the last screen update */
+	u_int refresh_delta;		/**< time step to next screen update */
 	/**@}*/
 } PrivateData;
 
 /* Local prototypes */
-static uint get_millisecond_time(void);
+static u_int get_millisecond_time(void);
 
 
 /* Vars for the server core */
@@ -303,7 +304,7 @@ rawserial_flush(Driver *drvthis)
 	PrivateData *p = drvthis->private_data;
 	char out[LCD_MAX_WIDTH * LCD_MAX_HEIGHT];
 
-	uint currentTime = get_millisecond_time();
+	u_int currentTime = get_millisecond_time();
 	int t_delta = currentTime - p->refresh_time;
 
 	/*
@@ -415,7 +416,7 @@ rawserial_get_info(Driver *drvthis)
  *
  * \return  int with current millisecond time.
  */
-static uint
+static u_int
 get_millisecond_time(void)
 {
 	struct timeval ts;


### PR DESCRIPTION
Fixes build failure "error: unknown type name 'uint'"
